### PR TITLE
Fix typo (Tcl_Tcl_GetWideIntOrLongFromObjGetWideIntFromObj -> Tcl_Get…

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -70,6 +70,7 @@ SHELL		= @SHELL@
 
 srcdir		= @srcdir@
 prefix		= @prefix@
+datarootdir = @datarootdir@
 exec_prefix	= @exec_prefix@
 
 bindir		= @bindir@

--- a/generic/ffidl.c
+++ b/generic/ffidl.c
@@ -547,7 +547,7 @@ EXTERN int	Ffidl_Init _ANSI_ARGS_((Tcl_Interp * interp));
 #else
 #define HAVE_WIDE_INT 1
 #define Tcl_NewWideIntOrLong Tcl_NewWideIntObj
-#define Tcl_GetWideIntOrLongFromObj Tcl_Tcl_GetWideIntOrLongFromObjGetWideIntFromObj
+#define Tcl_GetWideIntOrLongFromObj Tcl_GetWideIntFromObj
 #define Tcl_WideIntOrLong Tcl_WideInt
 #endif
 #endif

--- a/library/ffidlrt.tcl
+++ b/library/ffidlrt.tcl
@@ -99,10 +99,23 @@ namespace eval ::ffidl:: {
                         }
                     } else {
                         array set libs {
-                            c /lib/libc.so.6
-                            m /lib/libm.so.6
-                            gdbm /usr/lib/libgdbm.so
-                            gmp {/usr/local/lib/libgmp.so /usr/lib/libgmp.so.2}
+                            c {
+                                    /lib/libc.so.6
+                                    /lib/i386-linux-gnu/libc.so.6
+                            }
+                            m {
+                                    /lib/libm.so.6
+                                    /lib/i386-linux-gnu/libm.so.6
+                            }
+                            gdbm {
+                                    /usr/lib/libgdbm.so
+                                    /usr/lib/i386-linux-gnu/libgdbm.so.3
+                            }
+                            gmp {
+                                   /usr/lib/i386-linux-gnu/libgmp.so.2
+                                   /usr/local/lib/libgmp.so
+                                   /usr/lib/libgmp.so.2
+                            }
                             mathswig libmathswig0.5.so
                         }
                         array set types {


### PR DESCRIPTION
…WideIntOrLongFromObj) causing undefined symbol errors on x86/32-bit platforms